### PR TITLE
 Implement Aurora JNDI Datasource(context.xml) management compatibility

### DIFF
--- a/build.shared
+++ b/build.shared
@@ -15,7 +15,7 @@ dependencies {
     "junit:junit:4.12",
     "org.mockito:mockito-core:2.11.0",
     "org.jdbi:jdbi:2.78",
-    "com.zaxxer:HikariCP:2.6.1",
+    "com.zaxxer:HikariCP:2.7.2",
     "ch.qos.logback:logback-core:1.2.2",
     "ch.qos.logback:logback-classic:1.2.2"
   )

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,9 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.threadly</groupId>
 	<artifactId>auroraArc</artifactId>
-	<version>0.4</version>
+	<version>0.5</version>
 	<packaging>jar</packaging>
 
 	<name>AuroraArc</name>
@@ -29,6 +30,7 @@
 			<type>jar</type>
 			<optional>false</optional>
 		</dependency>
+		<!-- Test dependencies  -->
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
@@ -44,7 +46,7 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>1.2.2</version>
+			<version>2.7.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,50 +1,91 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.threadly</groupId>
-  <artifactId>auroraArc</artifactId>
-  <version>0.4</version>
-  <packaging>jar</packaging>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.threadly</groupId>
+	<artifactId>auroraArc</artifactId>
+	<version>0.4</version>
+	<packaging>jar</packaging>
 
-  <name>AuroraArc</name>
-  <description>A JDBC driver for handling secondary reads and advanced failover capabilities with AWS Aurora database clusters.</description>
-  <url>https://github.com/threadly/auroraArc</url>
+	<name>AuroraArc</name>
+	<description>A JDBC driver for handling secondary reads and advanced failover capabilities with AWS Aurora database clusters.</description>
+	<url>https://github.com/threadly/auroraArc</url>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.threadly</groupId>
-      <artifactId>threadly</artifactId>
-      <version>5.2</version>
-      <type>jar</type>
-      <optional>false</optional>
-    </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>6.0.6</version>
-      <type>jar</type>
-      <optional>false</optional>
-    </dependency>
-  </dependencies>
+	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
 
-  <licenses>
-    <license>
-      <name>Mozilla Public License Version 2.0</name>
-      <url>https://www.mozilla.org/MPL/2.0/</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+	<dependencies>
+		<dependency>
+			<groupId>org.threadly</groupId>
+			<artifactId>threadly</artifactId>
+			<version>5.8</version>
+			<type>jar</type>
+			<optional>false</optional>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>6.0.6</version>
+			<type>jar</type>
+			<optional>false</optional>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>1.2.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>1.2.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jdbi</groupId>
+			<artifactId>jdbi</artifactId>
+			<version>2.78</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.11.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
-  <scm>
-    <connection>scm:git:git@github.com:threadly/auroraArc.git</connection>
-    <developerConnection>scm:git:git@github.com:threadly/auroraArc.git</developerConnection>
-    <url>git@github.com:threadly/auroraArc.git</url>
-  </scm>
+	<licenses>
+		<license>
+			<name>Mozilla Public License Version 2.0</name>
+			<url>https://www.mozilla.org/MPL/2.0/</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
-  <developers>
-    <developer>
-      <id>jent</id>
-      <name>Mike Jensen</name>
-      <email>jent@threadly.org</email>
-    </developer>
-  </developers>
+	<scm>
+		<connection>scm:git:git@github.com:threadly/auroraArc.git</connection>
+		<developerConnection>scm:git:git@github.com:threadly/auroraArc.git</developerConnection>
+		<url>git@github.com:threadly/auroraArc.git</url>
+	</scm>
+
+	<developers>
+		<developer>
+			<id>jent</id>
+			<name>Mike Jensen</name>
+			<email>jent@threadly.org</email>
+		</developer>
+	</developers>
 </project>

--- a/src/main/java/org/threadly/db/aurora/AuroraDataSource.java
+++ b/src/main/java/org/threadly/db/aurora/AuroraDataSource.java
@@ -1,0 +1,323 @@
+package org.threadly.db.aurora;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.naming.Referenceable;
+import javax.naming.StringRefAddr;
+import javax.sql.DataSource;
+
+public final class AuroraDataSource implements DataSource, Referenceable, Serializable {
+
+	private static final String AURORA_PREFIX = "jdbc:mysql:aurora:";
+
+	private static final long serialVersionUID = 1L;
+
+	/** The driver to create connections with */
+    private static final NonRegisteringDriver driver;
+
+    static {
+        driver = new NonRegisteringDriver();
+    }
+	
+    /** Log stream */
+    protected transient PrintWriter logWriter = null;
+    
+    /** Database Name */
+    protected String databaseName = null;
+
+    /** Character Encoding */
+    protected String encoding = null;
+
+    /** Hostname */
+    protected String hostName = null;
+
+    /** Password */
+    protected String password = null;
+
+    /** The profileSQL property */
+    protected String profileSQLString = "false";
+
+    /** The JDBC URL */
+    protected String url = null;
+
+    /** User name */
+    protected String user = null;
+
+    /** Should we construct the URL, or has it been set explicitly */
+    protected boolean explicitUrl = false;
+
+    /** Port number */
+    protected int port = 3306;
+    
+    /**
+     * Default no-arg constructor for Serialization
+     */
+    public AuroraDataSource() {
+    	//Default constructor for Serialization...
+	}
+
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		return null;
+	}
+
+	@Override
+	public boolean isWrapperFor(Class<?> iface) throws SQLException {
+		return false;
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> iface) throws SQLException {
+		return null;
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		return getConnection(this.user, this.password);
+	}
+
+    /**
+     * Creates a new connection with the given username and passwordsetPropertiesViaRef
+     * 
+     * @param userID
+     *            the user id to connect with
+     * @param password
+     *            the password to connect with
+     * 
+     * @return a connection to the database
+     * 
+     * @throws SQLException
+     *             if an error occurs
+     */
+	@Override
+	public Connection getConnection(String userID, String pass) throws SQLException {
+        Properties props = new Properties();
+
+        if (userID != null) {
+            props.setProperty("user", userID);
+        }
+
+        if (pass != null) {
+            props.setProperty("password", pass);
+        }
+        
+        return getConnection(props);
+	}
+
+	@Override
+	public PrintWriter getLogWriter() throws SQLException {
+		return this.logWriter;
+	}
+
+	@Override
+	public int getLoginTimeout() throws SQLException {
+		return 0;
+	}
+
+    /**
+     * Sets the log writer for this data source.
+     * 
+     * @see javax.sql.DataSource#setLogWriter(PrintWriter)
+     */
+	@Override
+	public void setLogWriter(PrintWriter output) throws SQLException {
+        this.logWriter = output;
+    }
+
+	@Override
+	public void setLoginTimeout(int arg0) throws SQLException {
+		//Timeout not handled
+	}
+	
+    /**
+     * Sets the password
+     * 
+     * @param pass
+     *            the password
+     */
+    public void setPassword(String pass) {
+        this.password = pass;
+    }
+
+    /**
+     * Sets the database port.
+     * 
+     * @param p
+     *            the port
+     */
+    public void setPort(int p) {
+        this.port = p;
+    }
+
+    /**
+     * Returns the port number
+     * 
+     * @return the port number
+     */
+    public int getPort() {
+        return this.port;
+    }
+    
+    /**
+     * Sets the user ID.
+     * 
+     * @param userID
+     *            the User ID
+     */
+    public void setUser(String userID) {
+        this.user = userID;
+    }
+
+    /**
+     * Returns the configured user for this connection
+     * 
+     * @return the user for this connection
+     */
+    public String getUser() {
+        return this.user;
+    }
+    
+    /**
+     * Sets the database name.
+     * 
+     * @param dbName
+     *            the name of the database
+     */
+    public void setDatabaseName(String dbName) {
+        this.databaseName = dbName;
+    }
+
+    /**
+     * Gets the name of the database
+     * 
+     * @return the name of the database for this data source
+     */
+    public String getDatabaseName() {
+        return (this.databaseName != null) ? this.databaseName : "";
+    }
+	
+    /**
+     * Sets the server name.
+     * 
+     * @param serverName
+     *            the server name
+     */
+    public void setServerName(String serverName) {
+        this.hostName = serverName;
+    }
+
+    /**
+     * Returns the name of the database server
+     * 
+     * @return the name of the database server
+     */
+    public String getServerName() {
+        return (this.hostName != null) ? this.hostName : "";
+    }
+	
+    /**
+     * Sets the URL for this connection
+     * 
+     * @param url
+     *            the URL for this connection
+     */
+    public void setURL(String url) {
+        setUrl(url);
+    }
+
+    /**
+     * Returns the URL for this connection
+     * 
+     * @return the URL for this connection
+     */
+    public String getURL() {
+        return getUrl();
+    }
+
+    /**
+     * This method is used by the app server to set the url string specified
+     * within the datasource deployment descriptor. It is discovered using
+     * introspection and matches if property name in descriptor is "url".
+     * 
+     * @param url
+     *            url to be used within driver.connect
+     */
+    public void setUrl(String url) {
+        this.url = url;
+        this.explicitUrl = true;
+    }
+
+    /**
+     * Returns the JDBC URL that will be used to create the database connection.
+     * 
+     * @return the URL for this connection
+     */
+    public String getUrl() {
+        if (!this.explicitUrl) {
+            StringBuilder sbUrl = new StringBuilder(AURORA_PREFIX);
+            sbUrl.append("//").append(getServerName()).append(":").append(getPort()).append("/").append(getDatabaseName());
+            return sbUrl.toString();
+        }
+        return this.url;
+    }
+	
+	
+    /**
+     * Creates a connection using the specified properties.
+     * 
+     * @param props
+     *            the properties to connect with
+     * 
+     * @return a connection to the database
+     * 
+     * @throws SQLException
+     *             if an error occurs
+     */
+    protected java.sql.Connection getConnection(Properties props) throws SQLException {
+        final String jdbcUrlToUse = (!this.explicitUrl) ? getUrl() : this.url;
+        return driver.connect(jdbcUrlToUse, props);
+    }
+
+    /**
+     * Required method to support this class as a <CODE>Referenceable</CODE>.
+     * 
+     * @return a Reference to this data source
+     * 
+     * @throws NamingException
+     *             if a JNDI error occurs
+     */
+    @Override
+    public Reference getReference() throws NamingException {
+        String factoryName = AuroraDataSourceFactory.class.getName();
+        Reference ref = new Reference(getClass().getName(), factoryName, null);
+        ref.add(new StringRefAddr("user", getUser()));
+        ref.add(new StringRefAddr("password", this.password));
+        ref.add(new StringRefAddr("serverName", getServerName()));
+        ref.add(new StringRefAddr("port", String.valueOf(getPort())));
+        ref.add(new StringRefAddr("databaseName", getDatabaseName()));
+        ref.add(new StringRefAddr("url", getUrl()));
+        ref.add(new StringRefAddr("explicitUrl", String.valueOf(this.explicitUrl)));
+
+        return ref;
+    }
+	
+    /**
+     * Initializes driver properties that come from a JNDI reference (in the
+     * case of a javax.sql.DataSource bound into some name service that doesn't
+     * handle Java objects directly).
+     * 
+     * @param ref
+     *            The JNDI Reference that holds RefAddrs for all properties
+     */
+    public void setPropertiesViaRef(Reference ref) throws SQLException {
+    	//TODO implement it 
+    }
+}

--- a/src/main/java/org/threadly/db/aurora/AuroraDataSourceFactory.java
+++ b/src/main/java/org/threadly/db/aurora/AuroraDataSourceFactory.java
@@ -1,0 +1,79 @@
+package org.threadly.db.aurora;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
+
+public class AuroraDataSourceFactory implements ObjectFactory {
+    /**
+     * The class name for a standard MySQL DataSource.
+     */
+    protected final static String DATA_SOURCE_CLASS_NAME = AuroraDataSource.class.getName();
+
+    @Override
+    public Object getObjectInstance(Object refObj, Name nm, Context ctx, Hashtable<?, ?> env) throws Exception {
+        Reference ref = (Reference) refObj;
+        String className = ref.getClassName();
+
+        if ((className != null)
+                && (className.equals(DATA_SOURCE_CLASS_NAME))) {
+            final AuroraDataSource dataSource = (AuroraDataSource) Class.forName(className).newInstance();
+
+            int portNumber = 3306;
+
+            String portNumberAsString = nullSafeRefAddrStringGet("port", ref);
+
+            if (portNumberAsString != null) {
+                portNumber = Integer.parseInt(portNumberAsString);
+            }
+
+            dataSource.setPort(portNumber);
+
+            String user = nullSafeRefAddrStringGet("user", ref);
+
+            if (user != null) {
+                dataSource.setUser(user);
+            }
+
+            String password = nullSafeRefAddrStringGet("password", ref);
+
+            if (password != null) {
+                dataSource.setPassword(password);
+            }
+
+            String serverName = nullSafeRefAddrStringGet("serverName", ref);
+
+            if (serverName != null) {
+                dataSource.setServerName(serverName);
+            }
+
+            String databaseName = nullSafeRefAddrStringGet("databaseName", ref);
+
+            if (databaseName != null) {
+                dataSource.setDatabaseName(databaseName);
+            }
+
+            String explicitUrlAsString = nullSafeRefAddrStringGet("explicitUrl", ref);
+
+            if (explicitUrlAsString != null && Boolean.parseBoolean(explicitUrlAsString)) {
+                dataSource.setUrl(nullSafeRefAddrStringGet("url", ref));
+            }
+
+            dataSource.setPropertiesViaRef(ref);
+
+            return dataSource;
+        }
+
+        // We can't create an instance of the reference
+        return null;
+    }
+
+    private String nullSafeRefAddrStringGet(String referenceName, Reference ref) {
+        RefAddr refAddr = ref.get(referenceName);
+        return (refAddr != null) ? (String) refAddr.getContent() : null;
+    }
+}

--- a/src/main/java/org/threadly/db/aurora/Driver.java
+++ b/src/main/java/org/threadly/db/aurora/Driver.java
@@ -1,14 +1,7 @@
 package org.threadly.db.aurora;
 
-import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.util.Properties;
-import java.util.logging.Logger;
-
-import org.threadly.db.AbstractArcDriver;
 
 /**
  * Threadly's AuroraArc Driver.  This Driver will create multiple connections for each returned 
@@ -28,51 +21,22 @@ import org.threadly.db.AbstractArcDriver;
  * <li>{@code "optimizedStateUpdates=true"} - Experimental internal code that can provide performance gains
  * </ul>
  */
-public class Driver extends AbstractArcDriver {
+public class Driver extends NonRegisteringDriver implements java.sql.Driver {
   static {
     try {
       DriverManager.registerDriver(new Driver());
     } catch (SQLException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Can't register driver!", e);
     }
   }
   
   /**
-   * Another way to register the driver.  This is more convenient than `Class.forName(String)` as 
-   * no exceptions need to be handled (instead just relying on the compile time dependency).
+   * Construct a new driver and register it with DriverManager
+   * 
+   * @throws SQLException
+   *             if a database error occurs.
    */
-  public static void registerDriver() {
-    // Nothing needed, just a nicer way to initialize the static registration compared to Class.forName.
-  }
-
-  @Override
-  public Connection connect(String url, Properties info) throws SQLException {
-    if (DelegatingAuroraConnection.acceptsURL(url)) {
-      return new DelegatingAuroraConnection(url, info);
-    } else {
-      // JDBC spec specifies that if unhandled URL type at this point is provided, null should be returned
-      return null;
-    }
-  }
-
-  @Override
-  public boolean acceptsURL(String url) {
-    return DelegatingAuroraConnection.acceptsURL(url);
-  }
-
-  @Override
-  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
-    return DelegateDriver.getDriver().getPropertyInfo(url, info);
-  }
-
-  @Override
-  public boolean jdbcCompliant() {
-    // should be compliant since just depending on mysql connector
-    return DelegateDriver.getDriver().jdbcCompliant();
-  }
-
-  @Override
-  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
-    return DelegateDriver.getDriver().getParentLogger();
+  public Driver() throws SQLException {
+      // Required for Class.forName().newInstance()
   }
 }

--- a/src/main/java/org/threadly/db/aurora/NonRegisteringDriver.java
+++ b/src/main/java/org/threadly/db/aurora/NonRegisteringDriver.java
@@ -1,0 +1,70 @@
+package org.threadly.db.aurora;
+
+import java.sql.Connection;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.threadly.db.AbstractArcDriver;
+
+/**
+ * Threadly's AuroraArc NonRegisteringDriver.  This Driver will create multiple connections for each returned 
+ * connection it provides.  Using these connections to monitor the aurora state, and to distribute 
+ * queries to multiple aurora servers when possible.
+ * <p>
+ * This is different from most SQL drivers, in that there is shared state between all returned 
+ * connections.  This shared state allows things like fail conditions to be communicated quickly, 
+ * allowing for intelligence of how to mitigate problems, and use potential secondary / slave 
+ * servers as soon as possible.
+ * <p>
+ * In general the user does not need to concern themselves with this benefit.  Just be aware that 
+ * multiple connections will be established for every connection returned by this Driver.
+ * <p>
+ * Possible URL configuration options:
+ * <ul>
+ * <li>{@code "optimizedStateUpdates=true"} - Experimental internal code that can provide performance gains
+ * </ul>
+ */
+public class NonRegisteringDriver extends AbstractArcDriver {
+
+  /**
+   * Another way to register the driver.  This is more convenient than `Class.forName(String)` as 
+   * no exceptions need to be handled (instead just relying on the compile time dependency).
+   */
+  public static void registerDriver() {
+    // Nothing needed, just a nicer way to initialize the static registration compared to Class.forName.
+  }
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    if (DelegatingAuroraConnection.acceptsURL(url)) {
+      return new DelegatingAuroraConnection(url, info);
+    } else {
+      // JDBC spec specifies that if unhandled URL type at this point is provided, null should be returned
+      return null;
+    }
+  }
+
+  @Override
+  public boolean acceptsURL(String url) {
+    return DelegatingAuroraConnection.acceptsURL(url);
+  }
+
+  @Override
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+    return DelegateDriver.getDriver().getPropertyInfo(url, info);
+  }
+
+  @Override
+  public boolean jdbcCompliant() {
+    // should be compliant since just depending on mysql connector
+    return DelegateDriver.getDriver().jdbcCompliant();
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return DelegateDriver.getDriver().getParentLogger();
+  }
+}


### PR DESCRIPTION
With these changes I want to add the compatibility with a JNDI Datasource so that it can be easily configured inside application server context.xml.

Example configuration for context.xml:

```
<Resource 
	 dataSource.url="jdbc:mysql:aurora://localhost/mydatabase?characterEncoding=UTF-8&amp;useOldAliasMetadataBehavior=true"
	 dataSourceClassName="org.threadly.db.aurora.AuroraDataSource"
/>
```