### PR TITLE
DelegatingAuroraConnection: Allow more control on delegate choice

### DIFF
--- a/arcCommon/src/main/java/org/threadly/db/aurora/Driver.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/Driver.java
@@ -20,6 +20,11 @@ import java.sql.SQLException;
  * <ul>
  * <li>{@code "optimizedStateUpdates=true"} - Experimental internal code that can provide performance gains
  * </ul>
+ * Possible {@link DelegatingAuroraConnection} configuration (used through 
+ * {@link DelegatingAuroraConnection#setClientInfo(String, String)}):
+ * <ul>
+ * <li>{@link DelegatingAuroraConnection#CLIENT_INFO_NAME_DELEGATE_CHOICE} - Specify how the connection is chosen
+ * </ul>
  */
 public class Driver extends NonRegisteringDriver {
   static {

--- a/mysqlAuroraArc/src/test/java/org/threadly/db/aurora/DriverLocalDbLoadTest.java
+++ b/mysqlAuroraArc/src/test/java/org/threadly/db/aurora/DriverLocalDbLoadTest.java
@@ -1,6 +1,7 @@
 package org.threadly.db.aurora;
 
 import java.sql.Connection;
+import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,7 +77,13 @@ public class DriverLocalDbLoadTest {
 
   @Test
   public void a1_insertRecord() {
-    runLoad(true, 4, RUN_COUNT_REFERENCE / 2, (s) -> s.a1_insertRecord());
+    runLoad(true, 4, RUN_COUNT_REFERENCE / 2, (s) -> {
+      try {
+        s.a1_insertRecordSmart();
+      } catch (SQLClientInfoException e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   @Test
@@ -92,7 +99,13 @@ public class DriverLocalDbLoadTest {
 
   @Test
   public void a3_lookupSingleRecord() {
-    runLoad(true, 32, RUN_COUNT_REFERENCE * 100, (s) -> s.a3_lookupSingleRecord());
+    runLoad(true, 32, RUN_COUNT_REFERENCE * 100, (s) -> {
+      try {
+        s.a3_lookupSingleRecordSmart();
+      } catch (SQLClientInfoException e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   @Test

--- a/mysqlAuroraArc/src/test/java/org/threadly/db/aurora/DriverLocalDbTest.java
+++ b/mysqlAuroraArc/src/test/java/org/threadly/db/aurora/DriverLocalDbTest.java
@@ -3,6 +3,7 @@ package org.threadly.db.aurora;
 import static org.junit.Assert.*;
 
 import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.threadly.concurrent.UnfairExecutor;
 import org.threadly.db.LoggingDriver;
 import org.threadly.db.aurora.Driver;
 import org.threadly.util.Clock;
+import org.threadly.util.ExceptionUtils;
 import org.threadly.util.Pair;
 import org.threadly.util.StringUtils;
 import org.threadly.util.SuppressedStackRuntimeException;
@@ -88,8 +90,50 @@ public class DriverLocalDbTest {
   }
 
   @Test
-  public void a1_insertRecord() {
+  public void a1_insertRecordSmart() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_SMART);
     dao.insertRecord(StringUtils.makeRandomString(5));
+  }
+
+  @Test
+  public void a1_insertRecordAny() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY);
+    dao.insertRecord(StringUtils.makeRandomString(5));
+  }
+
+  @Test
+  public void a1_insertRecordMasterPrefered() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERED);
+    dao.insertRecord(StringUtils.makeRandomString(5));
+  }
+
+  @Test
+  public void a1_insertRecordMasterOnly() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_ONLY);
+    dao.insertRecord(StringUtils.makeRandomString(5));
+  }
+
+  @Test
+  public void a1_insertRecordSlavePrefered() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERED);
+    dao.insertRecord(StringUtils.makeRandomString(5));
+  }
+
+  @Test
+  public void a1_insertRecordSlaveOnlyFail() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_ONLY);
+    try {
+      dao.insertRecord(StringUtils.makeRandomString(5));
+      fail("Exception should have thrown");
+    } catch (Exception e) {
+      assertTrue(ExceptionUtils.hasCauseOfType(e, DelegatingAuroraConnection.NoAuroraServerException.class));
+    }
   }
 
   @Test
@@ -116,9 +160,67 @@ public class DriverLocalDbTest {
   }
 
   @Test
-  public void a3_lookupSingleRecord() {
+  public void a3_lookupSingleRecordSmart() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_SMART);
     Pair<Long, String> p = dao.lookupRecord(1);
     assertNotNull(p);
+  }
+
+  @Test
+  public void a3_lookupSingleRecordAny() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY);
+    Pair<Long, String> p = dao.lookupRecord(1);
+    assertNotNull(p);
+  }
+
+  @Test
+  public void a3_lookupSingleRecordMasterPrefered() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERED);
+    Pair<Long, String> p = dao.lookupRecord(1);
+    assertNotNull(p);
+  }
+
+  @Test
+  public void a3_lookupSingleRecordMasterOnly() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_ONLY);
+    Pair<Long, String> p = dao.lookupRecord(1);
+    assertNotNull(p);
+  }
+
+  @Test
+  public void a3_lookupSingleRecordSlavePrefered() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERED);
+    Pair<Long, String> p = dao.lookupRecord(1);
+    assertNotNull(p);
+  }
+
+  @Test
+  public void a3_lookupSingleRecordSlaveOnlyFail() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_ONLY);
+    try {
+      dao.lookupRecord(1);
+      fail("Exception should have thrown");
+    } catch (Exception e) {
+      assertTrue(ExceptionUtils.hasCauseOfType(e, DelegatingAuroraConnection.NoAuroraServerException.class));
+    }
+  }
+
+  @Test
+  public void a3_lookupSingleRecordFirstHalfSlaveOnlyFail() throws SQLClientInfoException {
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_HALF_1_REPLICA_ONLY);
+    try {
+      dao.lookupRecord(1);
+      fail("Exception should have thrown");
+    } catch (Exception e) {
+      assertTrue(ExceptionUtils.hasCauseOfType(e, DelegatingAuroraConnection.NoAuroraServerException.class));
+    }
   }
 
   @Test


### PR DESCRIPTION
This allows you to specify more precise what type of logic should be used in picking a delegate connection.
Previously the only control was through setting the readOnly status.  This behavior is still defaulted as the `Smart` option.
But in addition behaviors to use only the master, or only a secondary, or even distribute to specific secondary servers have been added.
This can allow for more performant control over which connections to use, but can also allow options to make better use of the cluster.

Please read the javadocs at the top of `DelegatingAuroraConnection` for more details on the different behaviors this now provides.

Intuitively the large `if` / `else` statement in `getDelegate()` looks scary performance wise to me.  However benchmarking shows this to be superior to setting a lambda function which represents what call to make.  I suspect it's the lookup from the lambda cache that burns us, so it may be faster if this setting is not being adjusted, but I think most use cases will set the value, do request, then reset to default.  So keeping the setting of the value optimized is very important.

This does have a `TODO` note around providing the ClientInfo details into the `DatabaseMetaData`.  This is more work than I had time to do right now, I think it is probably ok to release with those docs currently missing, but it's one of many TODO notes we should cleanup before a `1.0` release.