### PR TITLE
AuroraClusterMonitor reliability changes

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -20,7 +20,7 @@
 	<classpathentry kind="lib" path="build/dependencies/byte-buddy-1.7.9.jar"/>
 	<classpathentry kind="lib" path="build/dependencies/byte-buddy-agent-1.7.9.jar"/>
 	<classpathentry kind="lib" path="build/dependencies/mockito-core-2.13.0.jar"/>
-	<classpathentry kind="lib" path="mysqlAuroraArc/build/dependencies/mysql-connector-java-8.0.15.jar"/>
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/HikariCP-3.3.1.jar"/>
+	<classpathentry kind="lib" path="mysqlAuroraArc/build/dependencies/mysql-connector-java-8.0.16.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/arcCommon/src/main/java/org/threadly/db/AbstractErrorSqlConnection.java
+++ b/arcCommon/src/main/java/org/threadly/db/AbstractErrorSqlConnection.java
@@ -29,9 +29,9 @@ import org.threadly.util.ArgumentVerifier;
  * The connection will appear valid (from {@link #isValid(int)} and non-closed UNTIL the exception 
  * is thrown.  After that point the connection will appear as if it was closed.
  * 
- * @since 0.9
+ * @since 0.10
  */
-public class ErrorSqlConnection implements Connection {
+abstract class AbstractErrorSqlConnection implements Connection {
   private final Runnable errorThrownListener;
   private final SQLException sqlError;
   private final RuntimeException runtimeError;
@@ -39,12 +39,12 @@ public class ErrorSqlConnection implements Connection {
   private volatile boolean errorThrown = false;
   
   /**
-   * Construct a new {@link ErrorSqlConnection}.
+   * Construct a new {@link AbstractErrorSqlConnection}.
    * 
    * @param errorThrownListener Listener to be invoked when error is realized (ie thrown)
    * @param error Error to throw once Connection is attempted to be used
    */
-  public ErrorSqlConnection(Runnable errorThrownListener, SQLException error) {
+  public AbstractErrorSqlConnection(Runnable errorThrownListener, SQLException error) {
     ArgumentVerifier.assertNotNull(error, "error");
     
     if (errorThrownListener == null) {
@@ -57,12 +57,12 @@ public class ErrorSqlConnection implements Connection {
   }
 
   /**
-   * Construct a new {@link ErrorSqlConnection}.
+   * Construct a new {@link AbstractErrorSqlConnection}.
    * 
    * @param errorThrownListener Listener to be invoked when error is realized (ie thrown)
    * @param error Error to throw once Connection is attempted to be used
    */
-  public ErrorSqlConnection(Runnable errorThrownListener, RuntimeException error) {
+  public AbstractErrorSqlConnection(Runnable errorThrownListener, RuntimeException error) {
     ArgumentVerifier.assertNotNull(error, "error");
     
     if (errorThrownListener == null) {
@@ -93,11 +93,6 @@ public class ErrorSqlConnection implements Connection {
   @Override
   public boolean isClosed() {
     return errorThrown || closed;
-  }
-
-  @Override
-  public boolean isValid(int timeout) {
-    return ! isClosed();
   }
 
   @Override

--- a/arcCommon/src/main/java/org/threadly/db/ErrorInvalidSqlConnection.java
+++ b/arcCommon/src/main/java/org/threadly/db/ErrorInvalidSqlConnection.java
@@ -1,0 +1,40 @@
+package org.threadly.db;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Implementation of {@link Connection} which is perpetually in a state of error.  Any operation on 
+ * this connection will result in an exception being thrown.
+ * <p>
+ * The connection will appear invalid when checked by {@link #isValid(int)}, always returning 
+ * {@code false}.
+ * 
+ * @since 0.10
+ */
+public class ErrorInvalidSqlConnection extends AbstractErrorSqlConnection {
+  /**
+   * Construct a new {@link ErrorInvalidSqlConnection}.
+   * 
+   * @param errorThrownListener Listener to be invoked when error is realized (ie thrown)
+   * @param error Error to throw once Connection is attempted to be used
+   */
+  public ErrorInvalidSqlConnection(Runnable errorThrownListener, SQLException error) {
+    super(errorThrownListener, error);
+  }
+
+  /**
+   * Construct a new {@link ErrorInvalidSqlConnection}.
+   * 
+   * @param errorThrownListener Listener to be invoked when error is realized (ie thrown)
+   * @param error Error to throw once Connection is attempted to be used
+   */
+  public ErrorInvalidSqlConnection(Runnable errorThrownListener, RuntimeException error) {
+    super(errorThrownListener, error);
+  }
+
+  @Override
+  public boolean isValid(int timeout) {
+    return false;
+  }
+}

--- a/arcCommon/src/main/java/org/threadly/db/ErrorValidSqlConnection.java
+++ b/arcCommon/src/main/java/org/threadly/db/ErrorValidSqlConnection.java
@@ -1,0 +1,40 @@
+package org.threadly.db;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Implementation of {@link Connection} which is perpetually in a state of error.  Any operation on 
+ * this connection will result in an exception being thrown.
+ * <p>
+ * The connection will appear valid (from {@link #isValid(int)} and non-closed UNTIL the exception 
+ * is thrown.  After that point the connection will appear as if it was closed.
+ * 
+ * @since 0.10
+ */
+public class ErrorValidSqlConnection extends AbstractErrorSqlConnection {
+  /**
+   * Construct a new {@link ErrorValidSqlConnection}.
+   * 
+   * @param errorThrownListener Listener to be invoked when error is realized (ie thrown)
+   * @param error Error to throw once Connection is attempted to be used
+   */
+  public ErrorValidSqlConnection(Runnable errorThrownListener, SQLException error) {
+    super(errorThrownListener, error);
+  }
+
+  /**
+   * Construct a new {@link ErrorValidSqlConnection}.
+   * 
+   * @param errorThrownListener Listener to be invoked when error is realized (ie thrown)
+   * @param error Error to throw once Connection is attempted to be used
+   */
+  public ErrorValidSqlConnection(Runnable errorThrownListener, RuntimeException error) {
+    super(errorThrownListener, error);
+  }
+
+  @Override
+  public boolean isValid(int timeout) {
+    return ! isClosed();
+  }
+}

--- a/arcCommon/src/main/java/org/threadly/db/aurora/DelegateAuroraDriver.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/DelegateAuroraDriver.java
@@ -85,6 +85,18 @@ public abstract class DelegateAuroraDriver {
   public String getArcPrefix() {
     return arcPrefix;
   }
+  
+  /**
+   * Get the parameters specific for the connection used for checking the master / slave / health 
+   * check.  By default this will return a timezone of UTC and SSL disabled.  Each parameter should 
+   * be prefixed / delineated with {@code &}, this includes the first parameter.  If no parameters are 
+   * provided this should return the empty string.
+   * 
+   * @return A {@code non-null} list of parameters to affix to the status check URL
+   */
+  public String getStatusConnectURLParams() {
+    return "&serverTimezone=UTC&useSSL=false";
+  }
 
   /**
    * Get the delegated driver instance.

--- a/arcCommon/src/main/java/org/threadly/db/aurora/DelegatingAuroraConnection.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/DelegatingAuroraConnection.java
@@ -16,7 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.threadly.db.AbstractDelegatingConnection;
-import org.threadly.db.ErrorSqlConnection;
+import org.threadly.db.ErrorValidSqlConnection;
 import org.threadly.db.aurora.DelegatingAuroraConnection.ConnectionStateManager.ConnectionHolder;
 import org.threadly.util.Clock;
 import org.threadly.util.Pair;
@@ -211,7 +211,7 @@ public class DelegatingAuroraConnection extends AbstractDelegatingConnection imp
         }
         connections[i] = 
             new ConnectionStateManager.UnverifiedConnectionHolder(
-                new ErrorSqlConnection(this::closeSilently, e));
+                new ErrorValidSqlConnection(this::closeSilently, e));
       } catch (RuntimeException e) {
         LOG.log(Level.WARNING, "Delaying connect error for server: " + this.servers[i], e);
         if (connectException == null) {
@@ -219,7 +219,7 @@ public class DelegatingAuroraConnection extends AbstractDelegatingConnection imp
         }
         connections[i] = 
             new ConnectionStateManager.UnverifiedConnectionHolder(
-                new ErrorSqlConnection(this::closeSilently, e));
+                new ErrorValidSqlConnection(this::closeSilently, e));
       }
     }
     clusterMonitor = AuroraClusterMonitor.getMonitor(dDriver, this.servers);

--- a/arcCommon/src/test/java/org/threadly/db/AbstractErrorSqlConnectionTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/AbstractErrorSqlConnectionTest.java
@@ -1,8 +1,6 @@
 package org.threadly.db;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.sql.SQLException;
 import java.util.Collections;
@@ -14,17 +12,19 @@ import org.junit.Test;
 import org.threadly.test.concurrent.TestRunnable;
 import org.threadly.util.ExceptionUtils;
 
-public class ErrorSqlConnectionTest {
-  private static final SQLException ERROR = new SQLException();
+public abstract class AbstractErrorSqlConnectionTest {
+  protected static final SQLException ERROR = new SQLException();
 
-  private TestRunnable testListener;
-  private ErrorSqlConnection connection;
+  protected TestRunnable testListener;
+  protected AbstractErrorSqlConnection connection;
   
   @Before
   public void setup() {
     testListener = new TestRunnable();
-    connection = new ErrorSqlConnection(testListener, ERROR);
+    connection = makeConnection(testListener, ERROR);
   }
+  
+  protected abstract AbstractErrorSqlConnection makeConnection(Runnable testListener, SQLException error);
 
   @After
   public void cleanup() {
@@ -40,19 +40,8 @@ public class ErrorSqlConnectionTest {
     
     assertTrue(connection.isClosed());
   }
-
-  @Test
-  public void isValidTest() {
-    assertTrue(connection.isValid(0));
-    
-    
-    verifyAction(connection::error);
-    
-    assertFalse(connection.isValid(0));
-    assertTrue(connection.isClosed());
-  }
   
-  private void verifyAction(Callable<?> operation) {
+  protected void verifyAction(Callable<?> operation) {
     try {
       operation.call();
       fail("Exception should have thrown");

--- a/arcCommon/src/test/java/org/threadly/db/ErrorInvalidSqlConnectionTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/ErrorInvalidSqlConnectionTest.java
@@ -1,0 +1,21 @@
+package org.threadly.db;
+
+import static org.junit.Assert.*;
+
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+public class ErrorInvalidSqlConnectionTest extends AbstractErrorSqlConnectionTest {
+  @Override
+  protected AbstractErrorSqlConnection makeConnection(Runnable testListener, SQLException error) {
+    return new ErrorInvalidSqlConnection(testListener, error);
+  }
+
+  @Test
+  public void isValidTest() throws SQLException {
+    assertFalse(connection.isValid(0));
+    
+    verifyAction(connection::error);
+  }
+}

--- a/arcCommon/src/test/java/org/threadly/db/ErrorValidSqlConnectionTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/ErrorValidSqlConnectionTest.java
@@ -1,0 +1,24 @@
+package org.threadly.db;
+
+import static org.junit.Assert.*;
+
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+public class ErrorValidSqlConnectionTest extends AbstractErrorSqlConnectionTest {
+  @Override
+  protected AbstractErrorSqlConnection makeConnection(Runnable testListener, SQLException error) {
+    return new ErrorValidSqlConnection(testListener, error);
+  }
+
+  @Test
+  public void isValidTest() throws SQLException {
+    assertTrue(connection.isValid(0));
+    
+    verifyAction(connection::error);
+    
+    assertFalse(connection.isValid(0));
+    assertTrue(connection.isClosed());
+  }
+}

--- a/arcCommon/src/test/java/org/threadly/db/aurora/DelegateMockDriver.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/DelegateMockDriver.java
@@ -82,6 +82,7 @@ public class DelegateMockDriver {
         
         try {
           // mock out the behavior for secondary check on mysql
+          when(mockConnection.isValid(anyInt())).thenReturn(true);
           PreparedStatement mockStatement = mock(PreparedStatement.class);
           ResultSet mockResultSet = mock(ResultSet.class);
           when(mockStatement.executeQuery()).thenReturn(mockResultSet);

--- a/arcCommon/src/test/java/org/threadly/db/aurora/DelegatingAuroraConnectionTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/DelegatingAuroraConnectionTest.java
@@ -331,6 +331,7 @@ public class DelegatingAuroraConnectionTest {
   
   @Test
   public void closeTest() throws SQLException {
+    assertFalse(auroraConnection.isClosed());
     auroraConnection.close();
 
     assertTrue(auroraConnection.isClosed());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 group = org.threadly
 version = 0.10-SNAPSHOT
 
-threadlyVersion = 5.34
-mysqlVersion = 8.0.15
+threadlyVersion = 5.36
+mysqlVersion = 8.0.16
 psqlVersion = 42.2.5
 
 jdbiVersion = 2.78


### PR DESCRIPTION
This updates the transitive dependencies and attempts to change AuroraClusterMonitor logic for improved reliability.
There are several changes involved in this:
* First the connection is checked for isValid before it used to check master / slave status.  This hopefully prevents errors from invalid connections which might remove the server from selection

* Errors during connection are now delayed.  This allows the monitor to be constructed while some of the cluster is unhealthy.  The delayed error will still be found and logged quickly, it just wont prevent the monitor from being constructed (which may otherwise prevent an application from being usable / startup)

* Errors during regular scheduled state check are handled differently.  If an error occurs from an expedited state check the health status will still transition immediately.  This is desired because a connection has already witnessed an error so we should treat that seriously.  However if an error occurs from a regular check it will be ignored initially, with a new check scheduled quickly.  It's possible that new connections can't be established but existing ones are working, so we are attempting to delay impacting those existing connections use.  In the future we may want to inspect the error type to make even more decisions here.

* Added the ability to get notified on every cluster state check error, but only log when the error state changes