### PR TITLE
Add ColocatedPreferred delegate choice

### DIFF
--- a/arcCommon/src/main/java/org/threadly/db/aurora/AuroraClusterMonitor.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/AuroraClusterMonitor.java
@@ -153,7 +153,8 @@ public class AuroraClusterMonitor {
           return null;
         } else {
           long replicaIndex = this.replicaIndex.getAndIncrement();
-          return clusterStateChecker.secondaryServers.get((int)(replicaIndex % secondaryCount));
+          return clusterStateChecker.secondaryServers.get(
+            (int)(replicaIndex & 0x7FFF_FFFF) % secondaryCount);
         }
       } catch (IndexOutOfBoundsException e) {
         // secondary server was removed during check, loop and retry

--- a/arcCommon/src/main/java/org/threadly/db/aurora/AuroraServer.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/AuroraServer.java
@@ -7,19 +7,24 @@ import java.util.Properties;
  */
 public class AuroraServer implements Comparable<AuroraServer> {
   private static final int DEFAULT_PORT = 3306;
-  
+
   private final String host;
   private final int port;
   private final Properties info;
+  private final boolean colocated;
   private final int hashCode;
 
   /**
    * Construct a new {@link AuroraServer} for a given {@code host:post} string.
-   * 
+   *
    * @param server Host and port within a single string
    * @param info Properties for the connection
    */
   public AuroraServer(String server, Properties info) {
+    this(server, info, false);
+  }
+
+  AuroraServer(String server, Properties info, boolean colocated) {
     int delim = server.indexOf(':');
     if (delim > 0) {
       host = server.substring(0, delim).intern();
@@ -29,6 +34,7 @@ public class AuroraServer implements Comparable<AuroraServer> {
       port = DEFAULT_PORT;
     }
     this.info = info; // not currently considered in equality or hash
+    this.colocated = colocated;
 
     hashCode = this.host.hashCode() ^ port;
   }
@@ -41,9 +47,14 @@ public class AuroraServer implements Comparable<AuroraServer> {
    * @param info Properties for the connection
    */
   public AuroraServer(String host, int port, Properties info) {
+    this(host, port, info, false);
+  }
+
+  AuroraServer(String host, int port, Properties info, boolean colocated) {
     this.host = host.intern();
     this.port = port;
     this.info = info; // not currently considered in equality or hash
+    this.colocated = colocated;
 
     hashCode = this.host.hashCode() ^ port;
   }
@@ -113,5 +124,9 @@ public class AuroraServer implements Comparable<AuroraServer> {
    */
   public Properties getProperties() {
     return info;
+  }
+
+  boolean isColocated() {
+    return colocated;
   }
 }

--- a/arcCommon/src/main/java/org/threadly/db/aurora/DelegatingAuroraConnection.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/DelegatingAuroraConnection.java
@@ -123,12 +123,12 @@ public class DelegatingAuroraConnection extends AbstractDelegatingConnection imp
    */
   public static final String CLIENT_INFO_VALUE_DELEGATE_CHOICE_HALF_2_REPLICA_ONLY = "ReplicaPart2Only";
   /**
-   * Possible value for {@link #CLIENT_INFO_NAME_DELEGATE_CHOICE} to
+   * Possible value for {@link #CLIENT_INFO_NAME_DELEGATE_CHOICE} to 
    * {@link #setClientInfo(String, String)}.
    *
-   * <p> This value will try to pick a random server from the set that were marked "colocated" with
-   * the local process, without regard to whether any particular server is master or replica. If
-   * none are configured or none are available, behaves like
+   * <p> This value will try to pick a random server from the set that were marked "colocated" with 
+   * the local process, without regard to whether any particular server is master or replica. If 
+   * none are configured or none are available, behaves like 
    * {@link CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY}.
    *
    * @see PROPERTY_COLOCATED_SERVERS
@@ -138,17 +138,17 @@ public class DelegatingAuroraConnection extends AbstractDelegatingConnection imp
       CLIENT_INFO_VALUE_DELEGATE_CHOICE_SMART;
 
   /**
-   * Identifier for a connection property that can be set to inform AuroraArc which delegate servers
+   * Identifier for a connection property that can be set to inform AuroraArc which delegate servers 
    * are considered "colocated" with the local process.
    *
-   * <p>If set, the value should be a non-negative integer indicating the number of servers which
-   * are to be considered colocated. E.g., if a value of <em>n</em> is given, the servers at indices
+   * <p>If set, the value should be a non-negative integer indicating the number of servers which 
+   * are to be considered colocated. E.g., if a value of <em>n</em> is given, the servers at indices 
    * 0 through <em>n</em>-1 will be considered colocated with the local process.
    */
   public static final String PROPERTY_COLOCATED_SERVERS = "auroraArcColocatedServers";
 
   /**
-   * If this connection property is set to the value {@code true}, try to optimise state updates
+   * If this connection property is set to the value {@code true}, try to optimise state updates 
    * (such as transaction status) sent to the servers.
    */
   public static final String PROPERTY_OPTIMIZED_STATE_UPDATES = "optimizedStateUpdates";

--- a/arcCommon/src/test/java/org/threadly/db/aurora/DelegatingAuroraConnectionTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/DelegatingAuroraConnectionTest.java
@@ -119,10 +119,10 @@ public class DelegatingAuroraConnectionTest {
   
   @Test
   public void getDelegateMasterPrefered() throws SQLException {
-    auroraConnection.setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
-                                   DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERED);
-    
-    assertEquals(DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERED, 
+    auroraConnection.setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE,
+                                   DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERRED);
+
+    assertEquals(DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERRED,
                  auroraConnection.delegateChoice);
     
     assertEquals(MASTER_HOST, auroraConnection.getDelegate().getLeft().getHost());
@@ -141,10 +141,10 @@ public class DelegatingAuroraConnectionTest {
   
   @Test
   public void getDelegateReplicaPefered() throws SQLException {
-    auroraConnection.setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
-                                   DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERED);
-    
-    assertEquals(DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERED, 
+    auroraConnection.setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE,
+                                   DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERRED);
+
+    assertEquals(DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERRED,
                  auroraConnection.delegateChoice);
     
     assertEquals(REPLICA_HOST, auroraConnection.getDelegate().getLeft().getHost());

--- a/mysqlAuroraArc/src/test/java/org/threadly/db/aurora/DriverLocalDbTest.java
+++ b/mysqlAuroraArc/src/test/java/org/threadly/db/aurora/DriverLocalDbTest.java
@@ -111,8 +111,8 @@ public class DriverLocalDbTest {
 
   @Test
   public void a1_insertRecordMasterPrefered() throws SQLClientInfoException {
-    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
-                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERED);
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE,
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_MASTER_PREFERRED);
     dao.insertRecord(StringUtils.makeRandomString(5));
   }
 
@@ -125,8 +125,8 @@ public class DriverLocalDbTest {
 
   @Test
   public void a1_insertRecordSlavePrefered() throws SQLClientInfoException {
-    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE, 
-                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERED);
+    h.getConnection().setClientInfo(DelegatingAuroraConnection.CLIENT_INFO_NAME_DELEGATE_CHOICE,
+                                    DelegatingAuroraConnection.CLIENT_INFO_VALUE_DELEGATE_CHOICE_ANY_REPLICA_PREFERRED);
     dao.insertRecord(StringUtils.makeRandomString(5));
   }
 


### PR DESCRIPTION
Adds a `ColocatedPreferred` value for `DelegateChoice` which will round-robin among delegates which were marked "colocated" (as in colocated with the local process) if any are available. If none are available, it behaves like `Any`. The goal is to be able to have high-volume services avoid unnecessary cross-AZ bandwidth.

This does not give AuroraArc any ability to determine colocatedness itself. Instead, it simply takes an `auroraArcColocatedServers=N` URL parameter which designates the first N delegates listed in the URL as colocated. As far as considering "colocated" == "same AZ", there are several ways to determine this automatically, but they all require extra permissions for the AWS API, so different organisations may want to do it differently so I think it makes sense for AuroraArc itself to require the client code to take care of figuring that out.

There's a few tangentially related changes here:

- The options that would round-robin the replicas would start failing after ~2G database calls due to feeding negative numbers into `%`; that's now fixed by masking away the sign bit.

- `ReplicaPreferred` and `MasterPreferred` were misspelled. The old names are still recognised but the constants for them are deprecated.

- I have a commit that strips trailing whitespace from all the files because it was driving me bonkers. If you don't want that here I can rebase it away.