### PR TITLE
AuroraClusterMonitor: Allow weighted replica's

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="arcCommon/src/test/java"/>
+	<classpathentry kind="src" path="arcCommon/build/generated/sources/annotationProcessor/java/test"/>
+	<classpathentry excluding="org" kind="src" path="arcCommon/build/classes/java/test"/>
 	<classpathentry kind="src" path="psqlAuroraArc/src/test/java"/>
 	<classpathentry kind="src" path="mysqlAuroraArc/src/test/java"/>
 	<classpathentry kind="src" path="psqlAuroraArc/src/main/java"/>
@@ -20,15 +22,21 @@
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/slf4j-api-1.7.25.jar"/>
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/byte-buddy-1.10.5.jar"/>
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/byte-buddy-agent-1.10.5.jar"/>
-	<classpathentry kind="lib" path="arcCommon/build/dependencies/HikariCP-3.4.2.jar"/>
-	<classpathentry kind="lib" path="arcCommon/build/dependencies/mockito-core-3.2.4.jar"/>
-	<classpathentry kind="lib" path="mysqlAuroraArc/build/dependencies/mysql-connector-java-8.0.19.jar"/>
-	<classpathentry kind="lib" path="psqlAuroraArc/build/dependencies/postgresql-42.2.9.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/threadly-test"/>
 	<classpathentry kind="lib" path="build/dependencies/jdbi3-core-3.12.2.jar"/>
 	<classpathentry kind="lib" path="build/dependencies/jdbi3-sqlobject-3.12.2.jar"/>
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/antlr4-runtime-4.7.2.jar"/>
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/caffeine-2.8.0.jar"/>
 	<classpathentry kind="lib" path="arcCommon/build/dependencies/geantyref-1.3.7.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/commons-math3-3.2.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/jmh-core-1.21.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/jmh-generator-annprocess-1.21.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/jopt-simple-4.6.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/HikariCP-3.4.3.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/jdbi3-core-3.13.0.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/jdbi3-sqlobject-3.13.0.jar"/>
+	<classpathentry kind="lib" path="arcCommon/build/dependencies/mockito-core-3.3.3.jar"/>
+	<classpathentry kind="lib" path="mysqlAuroraArc/build/dependencies/mysql-connector-java-8.0.20.jar"/>
+	<classpathentry kind="lib" path="psqlAuroraArc/build/dependencies/postgresql-42.2.12.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/arcCommon/src/main/java/org/threadly/db/aurora/AuroraClusterMonitor.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/AuroraClusterMonitor.java
@@ -3,7 +3,6 @@ package org.threadly.db.aurora;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -89,41 +88,9 @@ public class AuroraClusterMonitor {
    */
   public static void setExceptionHandler(BiConsumer<AuroraServer, Throwable> handler) {
     if (handler == null) {
-      errorExceptionHandler = (server, error) -> { /* ignored */ };
-    } else {
-      errorExceptionHandler = handler;
+      handler = (server, error) -> { /* ignored */ };
     }
-  }
-  
-  /**
-   * Set a {@link AuroraClusterStateListener} to be invoked to provide status updates on cluster 
-   * state changes.  See the interface definition for details about each action.  It's critical 
-   * that no invocation of this listener blocks as it could block the cluster check thread.
-   * <p>
-   * After being set, on the next cluster check the listener will be invoked with 
-   * {@link AuroraClusterStateListener#newWriter(AuroraServer)} and 
-   * {@link AuroraClusterStateListener#newReplica(AuroraServer)} as appropriate to initialize the 
-   * current cluster state.
-   * <p>
-   * If the cluster is unable to be looked up an error will be thrown, thus it is important that 
-   * the database has been initialized before invoking this.
-   * 
-   * @param Collection of the aurora hosts which describe the cluster, should include `:port` suffixes
-   * @param listener Listener to be invoked on cluster state checks
-   */
-  public static void setClusterStateListener(Collection<String> clusterHosts, 
-                                             AuroraClusterStateListener listener) {
-    AuroraServer[] aServers = new AuroraServer[clusterHosts.size()];
-    int index = 0;
-    for (String host : clusterHosts) {
-      aServers[index++] = new AuroraServer(host, null);
-    }
-    
-    AuroraClusterMonitor clusterMonitor = MONITORS.get(new AuroraServersKey(aServers));
-    if (clusterMonitor == null) {
-      throw new RuntimeException("Could not find cluster, make sure it's running: " + clusterHosts);
-    }
-    clusterMonitor.clusterChecker.setClusterStateListener(listener);
+    errorExceptionHandler = handler;
   }
   
   /**
@@ -180,70 +147,6 @@ public class AuroraClusterMonitor {
                                     (s) -> new AuroraClusterMonitor(MONITOR_SCHEDULER,
                                                                     checkFrequencyMillis, 
                                                                     driver, mapKey.clusterServers));
-  }
-  
-  /**
-   * Listener invoked on Aurora cluster state changes.  It is critical that not invocations block 
-   * as it could impact monitoring the health of the cluster.
-   * 
-   * @since 0.14
-   */
-  public interface AuroraClusterStateListener {
-    /**
-     * Listener which ignores all invocations.
-     */
-    public AuroraClusterStateListener IGNORE_LISTENER = new AuroraClusterStateListener() {
-      @Override
-      public void newWriter(AuroraServer newMaster) { /* ignored */ }
-
-      @Override
-      public void unhealthyWriter(AuroraServer formerMaster) { /* ignored */ }
-
-      @Override
-      public void newReplica(AuroraServer newReplica) { /* ignored */ }
-
-      @Override
-      public void unhealthyReplica(AuroraServer formerReplica) { /* ignored */ }
-
-      @Override
-      public void clusterCheckComplete() { /* ignored */ }
-    };
-    
-    /**
-     * Invoked when a new server has become a writer.
-     * 
-     * @param newMaster Server which is now the cluster master
-     */
-    public void newWriter(AuroraServer newMaster);
-    
-    /**
-     * Invoked when a former master (notified through {@link #newWriter(AuroraServer)}) has become 
-     * unhealthy.
-     * 
-     * @param formerMaster Server which is no longer a writer
-     */
-    public void unhealthyWriter(AuroraServer formerMaster);
-    
-    /**
-     * Invoked when a replica server has joined the cluster.
-     * 
-     * @param newReplica Server which can be used as a replica
-     */
-    public void newReplica(AuroraServer newReplica);
-
-    /**
-     * Invoked when a former replica (notified through {@link #newReplica(AuroraServer)} has become 
-     * unhealthy.
-     * 
-     * @param formerReplica Server which is no longer a replica
-     */
-    public void unhealthyReplica(AuroraServer formerReplica);
-
-    /**
-     * Invoked at the completion of every cluster check.  This can be used to monitor the cluster 
-     * checker health, as well as commit pending cluster changes from other calls.
-     */
-    public void clusterCheckComplete();
   }
 
   protected final ClusterChecker clusterChecker;
@@ -410,8 +313,6 @@ public class AuroraClusterMonitor {
     protected final AtomicReference<AuroraServer> masterServer;
     protected final CopyOnWriteArrayList<AuroraServer> serversWaitingExpeditiedCheck;
     protected final ConcurrentMap<AuroraServer, Integer> pendingServerWeightUpdates;
-    private AuroraClusterStateListener clusterStateListener;
-    private volatile AuroraClusterStateListener replacementClusterStateListener = null;
     private volatile boolean initialized = false; // starts false to avoid updates while constructor is running
 
     protected ClusterChecker(SchedulerService scheduler, long checkIntervalMillis,
@@ -425,7 +326,6 @@ public class AuroraClusterMonitor {
       masterServer = new AtomicReference<>();
       serversWaitingExpeditiedCheck = new CopyOnWriteArrayList<>();
       pendingServerWeightUpdates = new ConcurrentHashMap<>();
-      clusterStateListener = AuroraClusterStateListener.IGNORE_LISTENER;
 
       for (AuroraServer server : clusterServers) {
         ServerMonitor monitor = new ServerMonitor(scheduler, driver, server, this);
@@ -453,16 +353,6 @@ public class AuroraClusterMonitor {
       }
       
       initialized = true;
-      signalToRun();
-    }
-    
-    public void setClusterStateListener(AuroraClusterStateListener listener) {
-      // set replacementClusterStateListener so that listener can be updated only on the cluster check thread
-      if (listener == null) {
-        replacementClusterStateListener = AuroraClusterStateListener.IGNORE_LISTENER;
-      } else {
-        replacementClusterStateListener = listener;
-      }
       signalToRun();
     }
 
@@ -499,7 +389,6 @@ public class AuroraClusterMonitor {
       masterServer = new AtomicReference<>();
       serversWaitingExpeditiedCheck = new CopyOnWriteArrayList<>();
       pendingServerWeightUpdates = new ConcurrentHashMap<>();
-      clusterStateListener = AuroraClusterStateListener.IGNORE_LISTENER;
 
       initialized = true;
     }
@@ -595,18 +484,6 @@ public class AuroraClusterMonitor {
         return; // ignore state updates still initialization is done
       }
       
-      if (replacementClusterStateListener != null) {
-        clusterStateListener = replacementClusterStateListener;
-        replacementClusterStateListener = null;
-        
-        // invoke with the current cluster state
-        AuroraServer as = masterServer.get();
-        if (as != null) {
-          clusterStateListener.newWriter(as);
-        }
-        replicaServers.forEach(clusterStateListener::newReplica);
-      }
-      
       ArrayList<AuroraServer> updatedWeightedReplicaServers = null;
       if (! pendingServerWeightUpdates.isEmpty()) {
         Iterator<Map.Entry<AuroraServer, Integer>> it = pendingServerWeightUpdates.entrySet().iterator();
@@ -642,8 +519,6 @@ public class AuroraClusterMonitor {
             if (! as.equals(masterServer.get())) {
               // either already was the master, or now is
               masterServer.set(as);
-              
-              clusterStateListener.newWriter(as);
               LOG.info("New master server: " + as);
             }
           } else {
@@ -651,9 +526,6 @@ public class AuroraClusterMonitor {
               // no longer a master, will need to find the new one
               masterServer.compareAndSet(as, null);
               checkAllServers();  // make sure we find a new master ASAP
-              
-              clusterStateListener.unhealthyWriter(as);
-              clusterStateListener.newReplica(as);
             }
             
             if (! replicaServers.contains(as)) {
@@ -665,8 +537,6 @@ public class AuroraClusterMonitor {
                 }
                 addWeightedServer(updatedWeightedReplicaServers, as);
               }
-              
-              clusterStateListener.newReplica(as);
             }
           }
         } else {
@@ -677,16 +547,12 @@ public class AuroraClusterMonitor {
               }
               removeWeightedServer(updatedWeightedReplicaServers, as);
             }
-            
-            clusterStateListener.unhealthyReplica(as);
             // TODO - removal of a replica server can indicate it will become a new primary
             //        How can we use this common behavior to recover quicker?
           } else if (as.equals(masterServer.get())) {
             // no master till we find a new one
             masterServer.compareAndSet(as, null);
             checkAllServers();  // make sure we find a new master ASAP
-            
-            clusterStateListener.unhealthyWriter(as);
           } // else, server is already known to be unhealthy, no change
         }
       }
@@ -701,8 +567,6 @@ public class AuroraClusterMonitor {
           weightedReplicaServers = updatedWeightedReplicaServers;
         }
       }
-      
-      clusterStateListener.clusterCheckComplete();
     }
   }
 

--- a/arcCommon/src/main/java/org/threadly/db/aurora/AuroraServer.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/AuroraServer.java
@@ -12,6 +12,7 @@ public class AuroraServer implements Comparable<AuroraServer> {
   private final int port;
   private final Properties info;
   private final int hashCode;
+  private int weight = 1;
 
   /**
    * Construct a new {@link AuroraServer} for a given {@code host:post} string.
@@ -48,13 +49,41 @@ public class AuroraServer implements Comparable<AuroraServer> {
     hashCode = this.host.hashCode() ^ port;
   }
   
+  protected void setWeight(int weight) {
+    this.weight = weight;
+  }
+  
+  protected int getWeight() {
+    return weight;
+  }
+  
   /**
    * Return the hostname for this server.
    * 
-   * @return Hostname for server instance
+   * @return Hostname for the server instance
    */
   public String getHost() {
     return host;
+  }
+  
+  /**
+   * Return the port for this server.
+   * 
+   * @return Port for the server instance
+   */
+  public int getPort() {
+    return port;
+  }
+  
+  /**
+   * Check if the host and port matches to this server.
+   * 
+   * @param host Network host which must match exactly
+   * @param port Server port used on host
+   * @return {@code true} if both host and port match exactly
+   */
+  public boolean matchHost(String host, int port) {
+    return this.host.equals(host) && this.port == port;
   }
 
   @Override
@@ -65,13 +94,8 @@ public class AuroraServer implements Comparable<AuroraServer> {
       AuroraServer as = (AuroraServer)o;
       /*if (hashCode != as.hashCode) {
         return false;
-      } else */if (! host.equals(as.host)) {
-        return false;
-      } else if (port != as.port) {
-        return false;
-      } else {
-        return true;
-      }
+      }*/
+      return matchHost(as.host, as.port);
     } else {
       return false;
     }

--- a/arcCommon/src/main/java/org/threadly/db/aurora/DelegatingAuroraConnection.java
+++ b/arcCommon/src/main/java/org/threadly/db/aurora/DelegatingAuroraConnection.java
@@ -455,19 +455,7 @@ public class DelegatingAuroraConnection extends AbstractDelegatingConnection imp
   }
   
   protected AuroraServer getAuroraServerAny() throws SQLException {
-    int secondaryCount = clusterMonitor.getHealthyReplicaCount();
-    AuroraServer server;
-    if (secondaryCount == 0 || ThreadLocalRandom.current().nextInt(secondaryCount + 1) == 0) {
-      server = clusterMonitor.getCurrentMaster();
-      if (server == null) {
-        server = clusterMonitor.getRandomReadReplica(); // retry with secondary
-      }
-    } else {
-      server = clusterMonitor.getRandomReadReplica();
-      if (server == null) {
-        server = clusterMonitor.getCurrentMaster(); // retry with master
-      }
-    }
+    AuroraServer server = clusterMonitor.getRandomAnyServer();
     if (server == null) {
       throw new NoAuroraServerException("No healthy servers");
     }

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
@@ -14,7 +14,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.threadly.concurrent.ReschedulingOperation;
 import org.threadly.concurrent.SubmitterScheduler;
-import org.threadly.db.aurora.AuroraClusterMonitor.AuroraClusterStateListener;
 import org.threadly.db.aurora.AuroraClusterMonitor.ClusterChecker;
 import org.threadly.db.aurora.AuroraClusterMonitor.ServerMonitor;
 import org.threadly.test.concurrent.TestableScheduler;
@@ -140,18 +139,6 @@ public class AuroraClusterMonitorClusterCheckerTest {
 
     for (ServerMonitor sm : clusterServers.values()) {
       assertFalse(sm.isHealthy()); // NPE should have made unhealthy
-    }
-  }
-  
-  @Test
-  public void listenerStateInitializedOnNextCheckTest() {
-    AuroraClusterStateListener mockListener = mock(AuroraClusterStateListener.class);
-    
-    clusterChecker.setClusterStateListener(mockListener);
-    assertEquals(1, testScheduler.advance(500));
-    
-    for (AuroraServer as : clusterServers.keySet()) {
-      verify(mockListener, times(1)).newReplica(eq(as));
     }
   }
   

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
@@ -150,12 +150,14 @@ public class AuroraClusterMonitorClusterCheckerTest {
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
 
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedAllServers.size());
     assertEquals(2, clusterChecker.weightedReplicaServers.size());
   }
   
   @Test
   public void setOneReplicaWeightToZeroTest() {
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedAllServers.size());
     assertEquals(2, clusterChecker.weightedReplicaServers.size());
 
     clusterChecker.queueReplicaWeightUpdate("host2", 3306, 0);
@@ -164,12 +166,14 @@ public class AuroraClusterMonitorClusterCheckerTest {
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
     
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(1, clusterChecker.weightedAllServers.size());
     assertEquals(1, clusterChecker.weightedReplicaServers.size());
   }
   
   @Test
   public void setAllReplicaWeightToZeroTest() {
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedAllServers.size());
     assertEquals(2, clusterChecker.weightedReplicaServers.size());
 
     clusterChecker.queueReplicaWeightUpdate("host1", 3306, 0);
@@ -179,6 +183,7 @@ public class AuroraClusterMonitorClusterCheckerTest {
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
     
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(0, clusterChecker.weightedAllServers.size());
     assertEquals(0, clusterChecker.weightedReplicaServers.size());
     assertEquals(0, clusterChecker.replicaServers.get(0).getWeight());
     assertEquals(0, clusterChecker.replicaServers.get(1).getWeight());
@@ -187,6 +192,7 @@ public class AuroraClusterMonitorClusterCheckerTest {
   @Test
   public void doubleOneReplicaWeightTest() {
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedAllServers.size());
     assertEquals(2, clusterChecker.weightedReplicaServers.size());
 
     clusterChecker.queueReplicaWeightUpdate("host1", 3306, 2);
@@ -195,6 +201,7 @@ public class AuroraClusterMonitorClusterCheckerTest {
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
     
     assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(3, clusterChecker.weightedAllServers.size());
     assertEquals(3, clusterChecker.weightedReplicaServers.size());
   }
   

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
@@ -54,6 +54,7 @@ public class AuroraClusterMonitorClusterCheckerTest {
     for (ServerMonitor sm : clusterServers.values()) {
       ((TestServerMonitor)sm).resetState();
     }
+    clusterChecker.run();
   }
   
   @After
@@ -139,6 +140,62 @@ public class AuroraClusterMonitorClusterCheckerTest {
     for (ServerMonitor sm : clusterServers.values()) {
       assertFalse(sm.isHealthy()); // NPE should have made unhealthy
     }
+  }
+  
+  @Test
+  public void ignoreSetReplicaWeightToOneTest() {
+    clusterChecker.queueReplicaWeightUpdate("host1", 3306, 1);
+    assertEquals(1, clusterChecker.pendingServerWeightUpdates.size());
+    assertEquals(1, testScheduler.advance(500));
+    assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
+
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+  }
+  
+  @Test
+  public void setOneReplicaWeightToZeroTest() {
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+
+    clusterChecker.queueReplicaWeightUpdate("host2", 3306, 0);
+    assertEquals(1, clusterChecker.pendingServerWeightUpdates.size());
+    assertEquals(1, testScheduler.advance(500));
+    assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
+    
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(1, clusterChecker.weightedSecondaryServers.size());
+  }
+  
+  @Test
+  public void setAllReplicaWeightToZeroTest() {
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+
+    clusterChecker.queueReplicaWeightUpdate("host1", 3306, 0);
+    clusterChecker.queueReplicaWeightUpdate("host2", 3306, 0);
+    assertEquals(2, clusterChecker.pendingServerWeightUpdates.size());
+    assertEquals(1, testScheduler.advance(500));
+    assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
+    
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(0, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(0, clusterChecker.secondaryServers.get(0).getWeight());
+    assertEquals(0, clusterChecker.secondaryServers.get(1).getWeight());
+  }
+  
+  @Test
+  public void doubleOneReplicaWeightTest() {
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+
+    clusterChecker.queueReplicaWeightUpdate("host1", 3306, 2);
+    assertEquals(1, clusterChecker.pendingServerWeightUpdates.size());
+    assertEquals(1, testScheduler.advance(500));
+    assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
+    
+    assertEquals(2, clusterChecker.secondaryServers.size());
+    assertEquals(3, clusterChecker.weightedSecondaryServers.size());
   }
   
   private static class TestServerMonitor extends ServerMonitor {

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
@@ -149,28 +149,28 @@ public class AuroraClusterMonitorClusterCheckerTest {
     assertEquals(1, testScheduler.advance(500));
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
 
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedReplicaServers.size());
   }
   
   @Test
   public void setOneReplicaWeightToZeroTest() {
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedReplicaServers.size());
 
     clusterChecker.queueReplicaWeightUpdate("host2", 3306, 0);
     assertEquals(1, clusterChecker.pendingServerWeightUpdates.size());
     assertEquals(1, testScheduler.advance(500));
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
     
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(1, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(1, clusterChecker.weightedReplicaServers.size());
   }
   
   @Test
   public void setAllReplicaWeightToZeroTest() {
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedReplicaServers.size());
 
     clusterChecker.queueReplicaWeightUpdate("host1", 3306, 0);
     clusterChecker.queueReplicaWeightUpdate("host2", 3306, 0);
@@ -178,24 +178,24 @@ public class AuroraClusterMonitorClusterCheckerTest {
     assertEquals(1, testScheduler.advance(500));
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
     
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(0, clusterChecker.weightedSecondaryServers.size());
-    assertEquals(0, clusterChecker.secondaryServers.get(0).getWeight());
-    assertEquals(0, clusterChecker.secondaryServers.get(1).getWeight());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(0, clusterChecker.weightedReplicaServers.size());
+    assertEquals(0, clusterChecker.replicaServers.get(0).getWeight());
+    assertEquals(0, clusterChecker.replicaServers.get(1).getWeight());
   }
   
   @Test
   public void doubleOneReplicaWeightTest() {
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(2, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(2, clusterChecker.weightedReplicaServers.size());
 
     clusterChecker.queueReplicaWeightUpdate("host1", 3306, 2);
     assertEquals(1, clusterChecker.pendingServerWeightUpdates.size());
     assertEquals(1, testScheduler.advance(500));
     assertEquals(0, clusterChecker.pendingServerWeightUpdates.size());
     
-    assertEquals(2, clusterChecker.secondaryServers.size());
-    assertEquals(3, clusterChecker.weightedSecondaryServers.size());
+    assertEquals(2, clusterChecker.replicaServers.size());
+    assertEquals(3, clusterChecker.weightedReplicaServers.size());
   }
   
   private static class TestServerMonitor extends ServerMonitor {

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorClusterCheckerTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.threadly.concurrent.ReschedulingOperation;
 import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.db.aurora.AuroraClusterMonitor.AuroraClusterStateListener;
 import org.threadly.db.aurora.AuroraClusterMonitor.ClusterChecker;
 import org.threadly.db.aurora.AuroraClusterMonitor.ServerMonitor;
 import org.threadly.test.concurrent.TestableScheduler;
@@ -139,6 +140,18 @@ public class AuroraClusterMonitorClusterCheckerTest {
 
     for (ServerMonitor sm : clusterServers.values()) {
       assertFalse(sm.isHealthy()); // NPE should have made unhealthy
+    }
+  }
+  
+  @Test
+  public void listenerStateInitializedOnNextCheckTest() {
+    AuroraClusterStateListener mockListener = mock(AuroraClusterStateListener.class);
+    
+    clusterChecker.setClusterStateListener(mockListener);
+    assertEquals(1, testScheduler.advance(500));
+    
+    for (AuroraServer as : clusterServers.keySet()) {
+      verify(mockListener, times(1)).newReplica(eq(as));
     }
   }
   

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorJMH.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorJMH.java
@@ -1,0 +1,226 @@
+package org.threadly.db.aurora;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.threadly.concurrent.ReschedulingOperation;
+import org.threadly.concurrent.SameThreadSubmitterExecutor;
+import org.threadly.concurrent.SubmitterScheduler;
+import org.threadly.db.aurora.AuroraClusterMonitor.ClusterChecker;
+import org.threadly.db.aurora.AuroraClusterMonitor.ServerMonitor;
+import org.threadly.test.concurrent.TestableScheduler;
+
+@Fork(2)
+@Warmup(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@SuppressWarnings("unused")
+public class AuroraClusterMonitorJMH {
+  private static final TestableScheduler TEST_SCHEDULER;
+  private static final ClusterChecker NOOP_CLUSTER_CHECKER;
+  private static final ClusterChecker WEIGHTED_CLUSTER_CHECKER;
+  private static final AuroraClusterMonitor WEIGHTED_MONITOR;
+  private static final ClusterChecker UNWEIGHTED_CLUSTER_CHECKER;
+  private static final AuroraClusterMonitor UNWEIGHTED_MONITOR;
+  private static final ClusterChecker ZEROWEIGHTED_CLUSTER_CHECKER;
+  private static final AuroraClusterMonitor ZEROWEIGHTED_MONITOR;
+  
+  static {
+    TEST_SCHEDULER = new TestableScheduler();
+
+    DelegateAuroraDriver masterMockDriver = mock(DelegateAuroraDriver.class);
+    DelegateAuroraDriver replicaMockDriver = mock(DelegateAuroraDriver.class);
+    try {
+      when(masterMockDriver.isMasterServer(any(AuroraServer.class), any())).thenReturn(true);
+      when(replicaMockDriver.isMasterServer(any(AuroraServer.class), any())).thenReturn(false);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    
+    Map<AuroraServer, ServerMonitor> weightedServers = new HashMap<>();
+    AuroraServer masterServer = new AuroraServer("masterHost", new Properties());
+    weightedServers.put(masterServer, 
+                        new TestServerMonitor(masterMockDriver, TEST_SCHEDULER, masterServer));
+    AuroraServer w0Server = new AuroraServer("replicaHostW0", new Properties());
+    weightedServers.put(w0Server, 
+                        new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, w0Server));
+    AuroraServer w1Server = new AuroraServer("replicaHostW1", new Properties());
+    weightedServers.put(w1Server, 
+                        new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, w1Server));
+    AuroraServer w2Server = new AuroraServer("replicaHostW2", new Properties());
+    weightedServers.put(w2Server, 
+                        new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, w2Server));
+    AuroraServer w10Server = new AuroraServer("replicaHostW10", new Properties());
+    weightedServers.put(w10Server, 
+                        new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, w10Server));
+    
+    NOOP_CLUSTER_CHECKER = new ClusterChecker(TEST_SCHEDULER, weightedServers);
+    WEIGHTED_CLUSTER_CHECKER = new ClusterChecker(TEST_SCHEDULER, weightedServers);
+    WEIGHTED_MONITOR = new AuroraClusterMonitor(WEIGHTED_CLUSTER_CHECKER);
+
+    NOOP_CLUSTER_CHECKER.queueReplicaWeightUpdate(w10Server.getHost(), w10Server.getPort(), 10);
+    NOOP_CLUSTER_CHECKER.queueReplicaWeightUpdate(w2Server.getHost(), w2Server.getPort(), 2);
+    NOOP_CLUSTER_CHECKER.queueReplicaWeightUpdate(w1Server.getHost(), w1Server.getPort(), 1);
+    NOOP_CLUSTER_CHECKER.queueReplicaWeightUpdate(w0Server.getHost(), w0Server.getPort(), 0);
+    WEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(w10Server.getHost(), w10Server.getPort(), 10);
+    WEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(w2Server.getHost(), w2Server.getPort(), 2);
+    WEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(w1Server.getHost(), w1Server.getPort(), 1);
+    WEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(w0Server.getHost(), w0Server.getPort(), 0);
+
+    Map<AuroraServer, ServerMonitor> unweightedServers = new HashMap<>();
+    unweightedServers.put(masterServer, 
+                          new TestServerMonitor(masterMockDriver, TEST_SCHEDULER, masterServer));
+    AuroraServer replica1Server = new AuroraServer("replicaHost1", new Properties());
+    unweightedServers.put(replica1Server, 
+                          new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, replica1Server));
+    AuroraServer replica2Server = new AuroraServer("replicaHost2", new Properties());
+    unweightedServers.put(replica2Server, 
+                          new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, replica2Server));
+    AuroraServer replica3Server = new AuroraServer("replicaHost3", new Properties());
+    unweightedServers.put(replica3Server, 
+                          new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, replica3Server));
+    AuroraServer replica4Server = new AuroraServer("replicaHost4", new Properties());
+    unweightedServers.put(replica4Server, 
+                          new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, replica4Server));
+    
+    UNWEIGHTED_CLUSTER_CHECKER = new ClusterChecker(TEST_SCHEDULER, unweightedServers);
+    UNWEIGHTED_MONITOR = new AuroraClusterMonitor(UNWEIGHTED_CLUSTER_CHECKER);
+
+    Map<AuroraServer, ServerMonitor> zeroweightedServers = new HashMap<>();
+    zeroweightedServers.put(masterServer, 
+                            new TestServerMonitor(masterMockDriver, TEST_SCHEDULER, masterServer));
+    AuroraServer zeroReplica1Server = new AuroraServer("zeroReplicaHost1", new Properties());
+    zeroweightedServers.put(zeroReplica1Server, 
+                            new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, zeroReplica1Server));
+    AuroraServer zeroReplica2Server = new AuroraServer("zeroReplicaHost2", new Properties());
+    zeroweightedServers.put(zeroReplica2Server, 
+                            new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, zeroReplica2Server));
+    AuroraServer zeroReplica3Server = new AuroraServer("zeroReplicaHost3", new Properties());
+    zeroweightedServers.put(zeroReplica3Server, 
+                            new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, zeroReplica3Server));
+    AuroraServer zeroReplica4Server = new AuroraServer("zeroReplicaHost4", new Properties());
+    zeroweightedServers.put(zeroReplica4Server, 
+                            new TestServerMonitor(replicaMockDriver, TEST_SCHEDULER, zeroReplica4Server));
+    
+    ZEROWEIGHTED_CLUSTER_CHECKER = new ClusterChecker(TEST_SCHEDULER, zeroweightedServers);
+    ZEROWEIGHTED_MONITOR = new AuroraClusterMonitor(UNWEIGHTED_CLUSTER_CHECKER);
+    
+    ZEROWEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(zeroReplica1Server.getHost(), zeroReplica1Server.getPort(), 0);
+    ZEROWEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(zeroReplica2Server.getHost(), zeroReplica2Server.getPort(), 0);
+    ZEROWEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(zeroReplica3Server.getHost(), zeroReplica3Server.getPort(), 0);
+    ZEROWEIGHTED_CLUSTER_CHECKER.queueReplicaWeightUpdate(zeroReplica4Server.getHost(), zeroReplica4Server.getPort(), 0);
+    
+    WEIGHTED_CLUSTER_CHECKER.run();
+    UNWEIGHTED_CLUSTER_CHECKER.run();
+    ZEROWEIGHTED_CLUSTER_CHECKER.run();
+    TEST_SCHEDULER.tick();   // setup monitors
+  }
+  
+  //@Test // uncomment to run jmh test through junit
+  public void run() throws Exception {
+    org.openjdk.jmh.Main.main(new String[] { AuroraClusterMonitorJMH.class.getName() });
+  }
+  
+  @Benchmark
+  @Group("updateCluster")
+  public void noOpUpdateRun() {
+    NOOP_CLUSTER_CHECKER.run();
+  }
+  
+  @Benchmark
+  @Group("updateCluster")
+  public void weightedReplicaUpdate() {
+    // clear servers so they can be re-added
+    WEIGHTED_CLUSTER_CHECKER.secondaryServers.clear();
+    WEIGHTED_CLUSTER_CHECKER.weightedSecondaryServers = Collections.emptyList();
+    
+    WEIGHTED_CLUSTER_CHECKER.run();
+  }
+  
+  @Benchmark
+  @Group("updateCluster")
+  public void unweightedReplicaUpdate() {
+    // clear servers so they can be re-added
+    UNWEIGHTED_CLUSTER_CHECKER.secondaryServers.clear();
+    UNWEIGHTED_CLUSTER_CHECKER.weightedSecondaryServers = Collections.emptyList();
+    
+    UNWEIGHTED_CLUSTER_CHECKER.run();
+  }
+  
+  @Benchmark
+  @Group("updateCluster")
+  public void zeroWeightReplicaUpdate() {
+    // clear servers so they can be re-added
+    ZEROWEIGHTED_CLUSTER_CHECKER.secondaryServers.clear();
+    ZEROWEIGHTED_CLUSTER_CHECKER.weightedSecondaryServers = Collections.emptyList();
+    
+    ZEROWEIGHTED_CLUSTER_CHECKER.run();
+  }
+  
+  @Benchmark
+  @Group("getServer")
+  public void currentMaster() {
+    WEIGHTED_MONITOR.getCurrentMaster();
+  }
+  
+  @Benchmark
+  @Group("getServer")
+  public void weightedRandomReplica() {
+    WEIGHTED_MONITOR.getRandomReadReplica();
+  }
+  
+  @Benchmark
+  @Group("getServer")
+  public void unweightedRandomReplica() {
+    UNWEIGHTED_MONITOR.getRandomReadReplica();
+  }
+  
+  @Benchmark
+  @Group("getServer")
+  public void zeroweightedRandomReplica() {
+    ZEROWEIGHTED_MONITOR.getRandomReadReplica();
+  }
+  
+  private static class TestServerMonitor extends ServerMonitor {
+    protected TestServerMonitor(DelegateAuroraDriver driver, SubmitterScheduler scheduler, 
+                                AuroraServer server) {
+      super(scheduler, driver, server, NoOpReschedulingOperation.INSTANCE);
+    }
+    
+    protected void reconnect() {
+      // ignore
+    }
+  }
+  
+  private static class NoOpReschedulingOperation extends ReschedulingOperation {
+    public static final NoOpReschedulingOperation INSTANCE = new NoOpReschedulingOperation();
+    
+    protected NoOpReschedulingOperation() {
+      super(SameThreadSubmitterExecutor.instance());
+    }
+
+    @Override
+    protected void run() {
+      // ignored
+    }
+  }
+}

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorJMH.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorJMH.java
@@ -150,8 +150,8 @@ public class AuroraClusterMonitorJMH {
   @Group("updateCluster")
   public void weightedReplicaUpdate() {
     // clear servers so they can be re-added
-    WEIGHTED_CLUSTER_CHECKER.secondaryServers.clear();
-    WEIGHTED_CLUSTER_CHECKER.weightedSecondaryServers = Collections.emptyList();
+    WEIGHTED_CLUSTER_CHECKER.replicaServers.clear();
+    WEIGHTED_CLUSTER_CHECKER.weightedReplicaServers = Collections.emptyList();
     
     WEIGHTED_CLUSTER_CHECKER.run();
   }
@@ -160,8 +160,8 @@ public class AuroraClusterMonitorJMH {
   @Group("updateCluster")
   public void unweightedReplicaUpdate() {
     // clear servers so they can be re-added
-    UNWEIGHTED_CLUSTER_CHECKER.secondaryServers.clear();
-    UNWEIGHTED_CLUSTER_CHECKER.weightedSecondaryServers = Collections.emptyList();
+    UNWEIGHTED_CLUSTER_CHECKER.replicaServers.clear();
+    UNWEIGHTED_CLUSTER_CHECKER.weightedReplicaServers = Collections.emptyList();
     
     UNWEIGHTED_CLUSTER_CHECKER.run();
   }
@@ -170,8 +170,8 @@ public class AuroraClusterMonitorJMH {
   @Group("updateCluster")
   public void zeroWeightReplicaUpdate() {
     // clear servers so they can be re-added
-    ZEROWEIGHTED_CLUSTER_CHECKER.secondaryServers.clear();
-    ZEROWEIGHTED_CLUSTER_CHECKER.weightedSecondaryServers = Collections.emptyList();
+    ZEROWEIGHTED_CLUSTER_CHECKER.replicaServers.clear();
+    ZEROWEIGHTED_CLUSTER_CHECKER.weightedReplicaServers = Collections.emptyList();
     
     ZEROWEIGHTED_CLUSTER_CHECKER.run();
   }

--- a/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorTest.java
+++ b/arcCommon/src/test/java/org/threadly/db/aurora/AuroraClusterMonitorTest.java
@@ -10,4 +10,16 @@ public class AuroraClusterMonitorTest {
     AuroraClusterMonitor.setServerCheckDelayMillis(0);
     fail("Exception expected");
   }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void setReplicaWeightNegativeFail() {
+    AuroraClusterMonitor.setReplicaWeight("host", 3360, -1);
+    fail("Exception expected");
+  }
+  
+  @Test (expected = IllegalArgumentException.class)
+  public void setReplicaWeightMaxFail() {
+    AuroraClusterMonitor.setReplicaWeight("host", 3360, 101);
+    fail("Exception expected");
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
   }
 
   compileTestJava {
-    options.compilerArgs << "-Xlint:all" << "-Werror"
+    options.compilerArgs << "-Xlint:all" << "-Xlint:-processing" << "-Werror"
   }
 
   plugins.withType(JavaPlugin) {
@@ -94,12 +94,15 @@ project(':arcCommon') {
       "org.threadly:threadly-test:$threadlyTestVersion",
       "junit:junit:$junitVersion",
       "org.mockito:mockito-core:$mockitoVersion",
+      "org.openjdk.jmh:jmh-core:$jmhVersion",
+      "org.openjdk.jmh:jmh-generator-annprocess:$jmhVersion",
       "org.jdbi:jdbi3-core:$jdbiVersion",
       "org.jdbi:jdbi3-sqlobject:$jdbiVersion",
       "com.zaxxer:HikariCP:$hikariVersion",
       "ch.qos.logback:logback-core:$logbackVersion",
       "ch.qos.logback:logback-classic:$logbackVersion"
     )
+    testAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:$jmhVersion"
 
     implementation (
       "org.threadly:threadly:$threadlyVersion"

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -78,7 +78,7 @@
       <property name="ignoredMethodNames" value="finalize, call, acceptConsumedItem"/>
     </module>
     <module name="MagicNumber">
-      <property name="ignoreNumbers" value="-2, -1, 0, 1, 2, 10, 100, 500, 1000"/>
+      <property name="ignoreNumbers" value="-2, -1, 0, 1, 2, 10, 64, 100, 500, 1000"/>
     </module>
     <module name="MissingSwitchDefault"/>
     <module name="NoFinalizer">

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,14 @@ group = org.threadly
 version = 0.14-SNAPSHOT
 org.gradle.parallel = false
 
-threadlyVersion = 6.0
+threadlyVersion = 6.1
 threadlyTestVersion = 1.0
-mysqlVersion = 8.0.19
-psqlVersion = 42.2.9
+mysqlVersion = 8.0.20
+psqlVersion = 42.2.12
 
-jdbiVersion = 3.12.2
-hikariVersion = 3.4.2
+jdbiVersion = 3.13.0
+hikariVersion = 3.4.3
 logbackVersion = 1.2.3
 junitVersion = 4.13
-mockitoVersion = 3.2.4
+mockitoVersion = 3.3.3
+jmhVersion = 1.21


### PR DESCRIPTION
This adds the static function `AuroraClusterMonitor.setReplicaWeight(String, int, int)` to be able to set weights for a given server.
As described in the javadocs, the weight effectively represents how many times that server should be choosen as a random replica among the cluster.
A weight of zero will prevent the server from being used unless it's the only available healthy replica.  While larger numbers will deliever additional traffic to those instances.

In addition dependency versions were updated and JMH was added as a test dependency.  A lot of benchmarking was done to make sure that this does not impact the performance of the driver.

In order to avoid performance impacts the weights are managed in additional collection.  Making the cluster state checker do a little additional logic to manage this collection.  Allowing the server selection logic to remain almost unchanged, and with no statistically significant performance impact.

It will be easier to see the logic change in the first commit in isolation.  I decided to do some minor renames as a second commit to this PR.

This PR resolves #2 