### PR TITLE
Allow setHostWeight() to work before cluster is started.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = org.threadly
-version = 0.14
+version = 0.15-SNAPSHOT
 org.gradle.parallel = false
 
 threadlyVersion = 6.2


### PR DESCRIPTION
Currently, it requires starting the cluster first, which makes configuration
needlessly awkward:

1. Configure the driver
2. Obtain at least one connection
3. Finish configuring the driver

In our use case, configuration is handled by a shared library, but when the
connection gets created is not under that library's control, so there's not
even an opportunity to call 3.

This modifies `setHostWeight()` to not fail if called bofer clusters have been
initialised, and instead stores the configured weight in a static map. As new
clusters are created, they pull weights from that map when they have a matching
server.